### PR TITLE
Fixed the error with updating a resource, at least in the quick update w...

### DIFF
--- a/core/components/babel/model/babel/babel.class.php
+++ b/core/components/babel/model/babel/babel.class.php
@@ -276,7 +276,7 @@ class Babel {
 	 * @param int $resourceId id of resource (int).
 	 */
 	public function initBabelTvById($resourceId) {
-		$resource = $this->modx->getObject('modResource', $resource);
+		$resource = $this->modx->getObject('modResource', $resourceId);
 		return $this->initBabelTv($resource);		
 	}
 	


### PR DESCRIPTION
...indow

Before I get this error;
Fatal error:  Call to a member function get() on a non-object in /***/core/components/babel/model/babel/babel.class.php on line 268

And this is not the line I have updated, but the initBabelTvById() wasn't passing the right variable why the initBabelTv() wasn't called with an modResource object parameter
