### PR TITLE
optimize OnResourceDuplicate

### DIFF
--- a/core/components/babel/elements/plugins/babel.plugin.php
+++ b/core/components/babel/elements/plugins/babel.plugin.php
@@ -292,7 +292,7 @@ switch ($modx->event->name) {
 		      
 		      	$q = $modx->newQuery('modResource');
 		        $q->select(array('id'));
-			$q->where(array('parent' => $id ));
+                        $q->where(array('parent' => $id ));
 		      	$children = $modx->getCollection('modResource', $q );
 		      
 			foreach ($children as $child) {


### PR DESCRIPTION
Optimation according Bob Ray's advice: http://forums.modx.com/thread/87517/modx--getchildids-not-working-in-onresourceduplicate-plugin#dis-post-482323. But be aware, it only works with the fixed $babel->initBabelTvById method https://github.com/mikrobi/babel/commit/7cafc9392a0df632d16a8c325af61da8f7b79299#diff-110135e006f328442d98c24b8b35b106.
