### PR TITLE
Skip unpublished contexts

### DIFF
--- a/core/components/babel/elements/snippets/babellinks.snippet.php
+++ b/core/components/babel/elements/snippets/babellinks.snippet.php
@@ -76,6 +76,9 @@ foreach($contextKeys as $contextKey) {
 		continue;
 	}
 	$context->prepare();
+	if (!$context->getOption('site_status',null,true)){
+	    continue;
+	}
 	$cultureKey = $context->getOption('cultureKey',$modx->getOption('cultureKey'));
 	$translationAvailable = false;
 	if(isset($linkedResources[$contextKey])) {


### PR DESCRIPTION
Contexts with site_status == 0 should be skipped I think...
