### PR TITLE
Skip empty default property set values

### DIFF
--- a/core/components/babel/elements/snippets/babeltranslation.snippet.php
+++ b/core/components/babel/elements/snippets/babeltranslation.snippet.php
@@ -49,12 +49,12 @@ if (empty($resourceId)) {
         return;
     }
 }
-$contextKey = $modx->getOption('contextKey', $scriptProperties, '');
+$contextKey = $modx->getOption('contextKey', $scriptProperties, '', true);
 if (empty($contextKey)) {
-    $cultureKey = $modx->getOption('cultureKey', $scriptProperties, '');
+    $cultureKey = $modx->getOption('cultureKey', $scriptProperties, '', true);
     $contextKey = $babel->getContextKey($cultureKey);
 }
-$showUnpublished = $modx->getOption('showUnpublished', $scriptProperties, 0);
+$showUnpublished = $modx->getOption('showUnpublished', $scriptProperties, 0, true);
 
 /* determine id of tranlated resource */
 $linkedResources = $babel->getLinkedResources($resourceId);


### PR DESCRIPTION
At the moment $cultureKey and $contextKey will be always empty if the snippet property is not set in the call, since the empty value in the default property set is never skipped.

Before the patch this does not work:
```
[[BabelTranslation? &resourceId=`22`]]
```
You have to use:
```
[[BabelTranslation? &resourceId=`22` &contextKey=`[[++context_key]]`]]
```