### PR TITLE
Equal height of the (locked) rows

### DIFF
--- a/assets/components/babel/css/babel.css
+++ b/assets/components/babel/css/babel.css
@@ -28,7 +28,7 @@
     height: 16px;
     margin-top: 6px;
     padding-top: 7px;
-    padding-bottom: 7px;
+    padding-bottom: 6px;
     margin-right: 6px;
 }
 


### PR DESCRIPTION
In Revo 2.4.4 the rows on the left (ID, Context, Title) have a different height than the rows on the right (babel contexts)