### PR TITLE
Accept a comma separated list of IDs in resourceId

### DIFF
--- a/core/components/babel/elements/snippets/babeltranslation.snippet.php
+++ b/core/components/babel/elements/snippets/babeltranslation.snippet.php
@@ -44,8 +44,8 @@ $resourceIds = $modx->getOption('resourceId', $scriptProperties);
 if (empty($resourceIds)) {
     if (!empty($modx->resource) && is_object($modx->resource)) {
         $resourceIds = $modx->resource->get('id');
-    } else {	
-        return;	
+    } else {
+        return;
     }
 }
 $resourceIds = array_map('trim', explode(',', $resourceIds));;

--- a/core/components/babel/elements/snippets/babeltranslation.snippet.php
+++ b/core/components/babel/elements/snippets/babeltranslation.snippet.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Babel
  *
@@ -41,14 +40,11 @@ if (!($babel instanceof Babel) || !$babel->babelTv)
     return;
 
 /* get snippet properties */
-$resourceId = intval($modx->getOption('resourceId', $scriptProperties));
-if (empty($resourceId)) {
-    if (!empty($modx->resource) && is_object($modx->resource)) {
-        $resourceId = $modx->resource->get('id');
-    } else {
-        return;
-    }
+$resourceIds = $modx->getOption('resourceId', $scriptProperties);
+if (empty($resourceIds)) {
+    return;
 }
+$resourceIds = array_map('trim', explode(',', $resourceIds));;
 $contextKey = $modx->getOption('contextKey', $scriptProperties, '', true);
 if (empty($contextKey)) {
     $cultureKey = $modx->getOption('cultureKey', $scriptProperties, '', true);
@@ -56,13 +52,15 @@ if (empty($contextKey)) {
 }
 $showUnpublished = $modx->getOption('showUnpublished', $scriptProperties, 0, true);
 
-/* determine id of tranlated resource */
-$linkedResources = $babel->getLinkedResources($resourceId);
-$output          = null;
-if (isset($linkedResources[$contextKey])) {
-    $resource = $modx->getObject('modResource', $linkedResources[$contextKey]);
-    if ($resource && ($showUnpublished || $resource->get('published') == 1)) {
-        $output = $resource->get('id');
+/* determine ids of translated resource */
+$output = array();
+foreach($resourceIds as $resourceId) {
+    $linkedResource = $babel->getLinkedResources($resourceId);
+    if (isset($linkedResources[$contextKey])) {
+        $resource = $modx->getObject('modResource', $linkedResources[$contextKey]);
+        if ($resource && ($showUnpublished || $resource->get('published') == 1)) {
+            $output[] = $resource->get('id');
+        }
     }
 }
-return $output;
+return implode(',', $output);

--- a/core/components/babel/elements/snippets/babeltranslation.snippet.php
+++ b/core/components/babel/elements/snippets/babeltranslation.snippet.php
@@ -56,8 +56,8 @@ $showUnpublished = $modx->getOption('showUnpublished', $scriptProperties, 0, tru
 $output = array();
 foreach($resourceIds as $resourceId) {
     $linkedResource = $babel->getLinkedResources($resourceId);
-    if (isset($linkedResources[$contextKey])) {
-        $resource = $modx->getObject('modResource', $linkedResources[$contextKey]);
+    if (isset($linkedResource[$contextKey])) {
+        $resource = $modx->getObject('modResource', $linkedResource[$contextKey]);
         if ($resource && ($showUnpublished || $resource->get('published') == 1)) {
             $output[] = $resource->get('id');
         }

--- a/core/components/babel/elements/snippets/babeltranslation.snippet.php
+++ b/core/components/babel/elements/snippets/babeltranslation.snippet.php
@@ -42,7 +42,11 @@ if (!($babel instanceof Babel) || !$babel->babelTv)
 /* get snippet properties */
 $resourceIds = $modx->getOption('resourceId', $scriptProperties);
 if (empty($resourceIds)) {
-    return;
+    if (!empty($modx->resource) && is_object($modx->resource)) {
+        $resourceIds = $modx->resource->get('id');
+    } else {	
+        return;	
+    }
 }
 $resourceIds = array_map('trim', explode(',', $resourceIds));;
 $contextKey = $modx->getOption('contextKey', $scriptProperties, '', true);


### PR DESCRIPTION
That way you could i.e. fill a &resources property of pdoResources with multiple translated resources.