### PR TITLE
Fix 500 error when a linked resource does not exist

### DIFF
--- a/core/components/babel/model/babel/babel.class.php
+++ b/core/components/babel/model/babel/babel.class.php
@@ -587,7 +587,7 @@ class Babel
                 $resourceId    = $linkedResources[$contextKey];
                 $resourceUrl   = '?a='.$actions['resource/update'].'&id='.$resourceId;
                 $linkResource  = $this->modx->getObject('modResource', $linkedResources[$contextKey]);
-                $resourceTitle = $linkResource->get('pagetitle');
+                $resourceTitle = $linkResource ? $linkResource->get('pagetitle') : '';
             } else {
                 $resourceId    = '';
                 $resourceUrl   = '#';


### PR DESCRIPTION
Fix 500 error when a linked resource does not exist.

Related issue:
https://github.com/mikrobi/babel/issues/167