### PR TITLE
Fix "getMatrixList" processor

### DIFF
--- a/assets/components/babel/js/mgr/widgets/grid.resourcematrix.js
+++ b/assets/components/babel/js/mgr/widgets/grid.resourcematrix.js
@@ -151,7 +151,7 @@ Babel.grid.ResourceMatrix = function (config) {
         id: 'babel-grid-resourcematrix',
         url: Babel.config.connectorUrl,
         baseParams: {
-            action: 'mgr/resource/getMatrixList',
+            action: 'mgr/resource/getmatrixlist',
             contexts: contexts.toString()
         },
         fields: fields,


### PR DESCRIPTION
Make the action all lower case to match the processor file name.
The "getMatrixList" processor  can't be loaded in MODX 3 on case-sensitive file systems.

https://community.modx.com/t/solved-babel-and-tv-links-not-working/5542