### PR TITLE
Change error level to warning when menu could not be loaded for context.

### DIFF
--- a/core/components/babel/elements/plugins/babel.plugin.php
+++ b/core/components/babel/elements/plugins/babel.plugin.php
@@ -81,7 +81,7 @@ switch ($modx->event->name) {
         $babel->config['languagesStore'] = $languagesStore;
         $babel->config['menu']           = $babel->getMenu($resource);
         if (empty($babel->config['menu'])) {
-            $modx->log(modX::LOG_LEVEL_ERROR, '[Babel] Could not load menu for context key: "'.$babel->config['context_key'].'". Try to check "babel.contextKeys" in System Settings. If this is intended, you can ignore this warning.');
+            $modx->log(modX::LOG_LEVEL_WARN, '[Babel] Could not load menu for context key: "'.$babel->config['context_key'].'". Try to check "babel.contextKeys" in System Settings. If this is intended, you can ignore this warning.');
             return;
         }
         $version         = str_replace(' ', '', $babel->config['version']);


### PR DESCRIPTION
Switch the error level from error to warn since this is not a real error. Prevents the error log from being flooded by this message. This is linked to issue https://github.com/mikrobi/babel/issues/177