### PR TITLE
Synchronise resource fields when saving

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -159,6 +159,11 @@
         "key": "syncTvs",
         "area": "system",
         "value": ""
+      },
+      {
+        "key": "syncFields",
+        "area": "system",
+        "value": ""
       }
     ]
   },

--- a/_build/resolvers/resolve.babelevents.php
+++ b/_build/resolvers/resolve.babelevents.php
@@ -68,7 +68,8 @@ $babelEvents = [
     'OnBabelDuplicate', // invoked on duplicating the resource in a new language context
     'OnBabelLink', // invoked on link the resource with a target resource
     'OnBabelUnlink', // invoked on unlink the resource from a target resource
-    'OnBabelTVSynced' // invoked when TVs are synchronized and changed
+    'OnBabelTVSynced', // invoked when TVs are synchronized and changed
+    'OnBabelFieldSynced' // invoked when resource fields are synchronized and changed
 ];
 
 $success = true;

--- a/_build/resolvers/resolve.setupoptions.php
+++ b/_build/resolvers/resolve.setupoptions.php
@@ -22,6 +22,7 @@ if ($object->xpdo) {
                 'contextKeys',
                 'babelTvName',
                 'syncTvs',
+                'syncFields',
             ];
             foreach ($settings as $key) {
                 if (isset($options[$key])) {

--- a/_build/setup.options.php
+++ b/_build/setup.options.php
@@ -21,6 +21,7 @@ $defaults = [
     'contextKeys' => implode(',', $contextKeys),
     'babelTvName' => 'babelLanguageLinks',
     'syncTvs' => '',
+    'syncFields' => '',
 ];
 
 $output = '<style type="text/css">
@@ -59,7 +60,12 @@ switch ($options[xPDOTransport::PACKAGE_ACTION]) {
                 <label for="babel-syncTvs">IDs of TVs to be synchronized (comma-separated):</label>
                 <input type="text" name="syncTvs" id="babel-syncTvs" width="450" value="' . $defaults['syncTvs'] . '" style="font-size: 13px; padding: 5px; width: calc(100% - 10px); height: 32px; margin-bottom: 10px" />
                 <p>Hint: Leave blank if no TVs should be synchronized.</p>
-          </div>';
+            </div>';
+        $output .= '<div style="position: relative">
+                <label for="babel-syncFields">IDs of resource fields to be synchronized (comma-separated):</label>
+                <input type="text" name="syncFields" id="babel-syncFields" width="450" value="' . $defaults['syncFields'] . '" style="font-size: 13px; padding: 5px; width: calc(100% - 10px); height: 32px; margin-bottom: 10px" />
+                <p>Hint: Leave blank if no resource fields should be synchronized.</p>
+            </div>';
         break;
     case xPDOTransport::ACTION_UPGRADE:
         $setting = $modx->getObject('modSystemSetting', ['key' => 'babel.contextKeys']);
@@ -72,6 +78,10 @@ switch ($options[xPDOTransport::PACKAGE_ACTION]) {
 
         $setting = $modx->getObject('modSystemSetting', ['key' => 'babel.syncTvs']);
         $values['syncTvs'] = ($setting) ? (bool)$setting->get('value') : $defaults['syncTvs'];
+        unset($setting);
+        
+        $setting = $modx->getObject('modSystemSetting', ['key' => 'babel.syncFields']);
+        $values['syncFields'] = ($setting) ? (bool)$setting->get('value') : $defaults['syncFields'];
         unset($setting);
 
         $output .= '<h2>Upgrade Babel</h2>
@@ -102,7 +112,12 @@ switch ($options[xPDOTransport::PACKAGE_ACTION]) {
                 <label for="babel-syncTvs">IDs of TVs to be synchronized (comma-separated):</label>
                 <input type="text" name="syncTvs" id="babel-syncTvs" width="450" value="' . $values['syncTvs'] . '" style="font-size: 13px; padding: 5px; width: calc(100% - 10px); height: 32px; margin-bottom: 10px" />
                 <p>Hint: Leave blank if no TVs should be synchronized.</p>
-          </div>';
+            </div>';
+        $output .= '<div style="position: relative">
+                <label for="babel-syncFields">IDs of resource fields to be synchronized (comma-separated):</label>
+                <input type="text" name="syncFields" id="babel-syncFields" width="450" value="' . $defaults['syncFields'] . '" style="font-size: 13px; padding: 5px; width: calc(100% - 10px); height: 32px; margin-bottom: 10px" />
+                <p>Hint: Leave blank if no resource fields should be synchronized.</p>
+            </div>';
         break;
     case xPDOTransport::ACTION_UNINSTALL:
         break;

--- a/core/components/babel/docs/changelog.md
+++ b/core/components/babel/docs/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2024-09-18
+
+### Added
+
+- Add system setting "babel.syncFields" to sync resource fields on save
+
 ## [3.3.4] - 2024-06-23
 
 ### Added

--- a/core/components/babel/lexicon/de/setting.inc.php
+++ b/core/components/babel/lexicon/de/setting.inc.php
@@ -17,3 +17,5 @@ $_lang['setting_babel.restrictToGroup'] = 'Auf Gruppe beschränken';
 $_lang['setting_babel.restrictToGroup_desc'] = 'Beschränkt die Kontexte in der Babel-Schaltfläche auf die Gruppe des aktuellen Kontexts.';
 $_lang['setting_babel.syncTvs'] = 'Synchronisierte TVs';
 $_lang['setting_babel.syncTvs_desc'] = 'Kommagetrennte Liste von Template Variable (TVs) IDs, die von Babel synchronisiert werden sollen.';
+$_lang['setting_babel.syncFields'] = 'Synchronisierte Ressourcen Felder';
+$_lang['setting_babel.syncFields_desc'] = 'Kommagetrennte Liste von Ressourcen Feldnamen, die von Babel synchronisiert werden sollen.';

--- a/core/components/babel/lexicon/en/setting.inc.php
+++ b/core/components/babel/lexicon/en/setting.inc.php
@@ -17,3 +17,6 @@ $_lang['setting_babel.restrictToGroup'] = 'Restrict To Group';
 $_lang['setting_babel.restrictToGroup_desc'] = 'Restrict the contexts in the Babel button to the group of the current context.';
 $_lang['setting_babel.syncTvs'] = 'Synchronized TVs';
 $_lang['setting_babel.syncTvs_desc'] = 'Comma separated list of template variables (TVs) IDs to be synchronised by Babel.';
+$_lang['setting_babel.syncFields'] = 'Synchronized resource fields';
+$_lang['setting_babel.syncFields_desc'] = 'Comma separated list of resource field names to be synchronised by Babel.';
+

--- a/core/components/babel/src/Plugins/Events/OnDocFormSave.php
+++ b/core/components/babel/src/Plugins/Events/OnDocFormSave.php
@@ -38,5 +38,6 @@ class OnDocFormSave extends Plugin
             return;
         }
         $this->babel->synchronizeTvs($resource->get('id'));
+        $this->babel->synchronizeFields($resource->get('id'));
     }
 }

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -132,14 +132,15 @@ given context. It uses the following snippet properties:
 
 Babel uses the following system settings in the namespace `babel`:
 
-| Key                   | Name              | Description                                                                                                                             | Default            |
-|-----------------------|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------|--------------------|
-| babel.babelTvName     | Babel TV Name     | Name of template variable (TV) in which Babel will store the links between multilingual resources. This TV will be maintained by Babel. | babelLanguageLinks |
-| babel.contextKeys     | Context Keys      | Comma separated list of context keys which should be used to link multilingual resources.                                               | -                  |
-| babel.debug           | Debug             | Log debug information in the MODX error log.                                                                                            | No                 |
-| babel.displayText     | Button Text       | Text shown in the Babel button for each context. You can use the following values: 'language', 'context' or 'combination'               | language           |
-| babel.restrictToGroup | Restrict To Group | Restrict the contexts in the Babel button to the group of the current context.                                                          | Yes                |
-| babel.syncTvs         | Synchronized TVs  | Comma separated list of template variables (TVs) IDs to be synchronised by Babel.                                                       | -                  |
+| Key                   | Name                | Description                                                                                                                             | Default            |
+|-----------------------|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------|--------------------|
+| babel.babelTvName     | Babel TV Name       | Name of template variable (TV) in which Babel will store the links between multilingual resources. This TV will be maintained by Babel. | babelLanguageLinks |
+| babel.contextKeys     | Context Keys        | Comma separated list of context keys which should be used to link multilingual resources.                                               | -                  |
+| babel.debug           | Debug               | Log debug information in the MODX error log.                                                                                            | No                 |
+| babel.displayText     | Button Text         | Text shown in the Babel button for each context. You can use the following values: 'language', 'context' or 'combination'               | language           |
+| babel.restrictToGroup | Restrict To Group   | Restrict the contexts in the Babel button to the group of the current context.                                                          | Yes                |
+| babel.syncTvs         | Synchronized TVs    | Comma separated list of template variables (TVs) IDs to be synchronised by Babel.                                                       | -                  |
+| babel.syncFields      | Synchronized Fields | Comma separated list of resource fields to be synchronised by Babel.                                                                    | -                  |
 
 The button text in the Babel button can use the following values:
 
@@ -206,7 +207,18 @@ uses the following parameters:
 This event is invoked when TVs are synced and changed. It uses the following
 parameters:
 
-| Parameter   | Description                                                                                                      |                                                                                                                   
-|-------------|------------------------------------------------------------------------------------------------------------------|
-| tv_changes  | An array of the changes in the synced TVs. Each array element contains the values tv_id, tv_value and target_id. |
-| resource_id | The ID of the resource the changes are synced from.                                                              |
+| Parameter   | Description                                                                                                   |
+|-------------|---------------------------------------------------------------------------------------------------------------|
+| tv_changes  | An array of the changes in the synced TVs. Each array element contains the values tvId, tvValue and targetId. |
+| resource_id | The ID of the resource the changes are synced from.                                                           |
+
+### OnBabelFieldSynced
+
+This event is invoked when resource fields are synced and changed. It uses the following
+parameters:
+
+| Parameter    | Description                                                                                                                            |
+|--------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| fieldChanges | An array of the changes in the synced resource fields. Each array element contains the values resourceId, resourceValue and linkedId. |
+| resource_id  | The ID of the resource the changes are synced from.                                                                                   |
+


### PR DESCRIPTION
This PR adds a new function `synchronizeFields()` on save. The resource fields can be set via a system setting `babel.syncFields`. See #218.

### Test

1. Set the system setting `babel.syncFields` to `published,unpub_date`.
2. Save a resource with associated babel resources.
3. Check if the fields `published` and `unpub_date` are synchronised.